### PR TITLE
Migrate to GitHub environment files

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
           else
             args=( --skip-publish )
           fi
-          echo "::set-output name=goreleaser_args::${args[*]}"
+          echo "goreleaser_args=${args[*]}" >> $GITHUB_OUTPUT
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3


### PR DESCRIPTION
`set-output` is deprecated and has been replaced with a temporary file whose path is made available in `$GITHUB_OUTPUT`.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/