### PR TITLE
Add a workaround for `lvm fullreport` sometimes including escaped nulls in strings

### DIFF
--- a/lvmreport/reader_test.go
+++ b/lvmreport/reader_test.go
@@ -49,6 +49,14 @@ func TestReader(t *testing.T) {
 				VG: []Row{},
 			},
 		},
+		{
+			name:  "escaped nulls in report",
+			input: `{"report": [{"vg": [{"a": "1\0\0\0"}], "lv": [{"a": "\02\0"}]}]}`,
+			want: &ReportData{
+				LV: []Row{{"a": "2"}},
+				VG: []Row{{"a": "1"}},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, decodeCalls := range []int{0, 1, 7} {


### PR DESCRIPTION
This results in invalid JSON. Which means the parsing fails. This is a bug of LVM, but since fixing that upstream could take a while, we have the workaround here.

Closes https://github.com/hansmi/prometheus-lvm-exporter/issues/92